### PR TITLE
Fix spaces in download url

### DIFF
--- a/lostprophecies.json
+++ b/lostprophecies.json
@@ -19,7 +19,7 @@
     "links": {
       "image": "https://raw.githubusercontent.com/Fropaccino/lostprophecies/main/lost_prophecies_16_9_cropped.png",
       "readme": "https://github.com/Fropaccino/lostprophecies",
-      "download": "https://authored-files.wabbajack.org/Lost Prophecies 2.8.2.wabbajack_b42abdb3-9a7b-42b2-a7b7-c51383eca81a",
+      "download": "https://authored-files.wabbajack.org/Lost%20Prophecies%202.8.2.wabbajack_b42abdb3-9a7b-42b2-a7b7-c51383eca81a",
       "machineURL": "LostProphecies",
       "discordURL": "http://discord.gg/fNgshCXE3h",
       "websiteURL": ""


### PR DESCRIPTION
This should fix the issue of the Archive Search on the Wabbajack website.